### PR TITLE
Fix message trimming that resulted in trailing backslashes

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -317,7 +317,9 @@ Notification.prototype.trim = function(length) {
 		return length - tooLong;
 	}
 	escaped = this.truncateStringToLength(escaped, length - tooLong);
-	escaped = escaped.replace(/(\\+|\\x\d{0,1}|\\u\d{0,3})$/, '');
+	escaped = escaped.replace(/(\\x\d{0,1}|\\u\d{0,3})$/, '');
+	// Make sure we end with an even number of backslashes
+	escaped = escaped.replace(/\\+$/, function(a){ return a.length % 2 === 0 ? a : a.slice(0, -1); });
 	escaped = JSON.parse('"' + escaped + '"');
 
 	if (typeof this.alert == "string") {

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -317,7 +317,7 @@ Notification.prototype.trim = function(length) {
 		return length - tooLong;
 	}
 	escaped = this.truncateStringToLength(escaped, length - tooLong);
-	escaped = escaped.replace(/(\\|\\x\d{0,1}|\\u\d{0,3})$/, '');
+	escaped = escaped.replace(/(\\+|\\x\d{0,1}|\\u\d{0,3})$/, '');
 	escaped = JSON.parse('"' + escaped + '"');
 
 	if (typeof this.alert == "string") {

--- a/test/notification.js
+++ b/test/notification.js
@@ -45,4 +45,10 @@ describe("Notification", function() {
 		note.length().should.be.at.most(256);
 	});
 
+	it("should trim long messages that, upon trimming, end in an escaped trailing backslash", function () {
+		note.alert = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\a';
+		note.trim(256);
+		note.length().should.be.at.most(256);
+	});
+
 });

--- a/test/notification.js
+++ b/test/notification.js
@@ -48,7 +48,13 @@ describe("Notification", function() {
 	it("should trim long messages that, upon trimming, end in an escaped trailing backslash", function () {
 		note.alert = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\a';
 		note.trim(256);
-		note.length().should.be.at.most(256);
+		note.length().should.equal(256);
+	});
+
+	it("should trim long messages that, upon trimming, end in an escaped and unescaped trailing backslashes", function () {
+		note.alert = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\\n';
+		note.trim(256);
+		note.length().should.equal(255);
 	});
 
 });


### PR DESCRIPTION
It would trim only the last, leaving an uneven number, accidentally escaping the final quote added when re-parsing the body.