### PR TITLE
Prevent exit when connection attempt fails.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -238,9 +238,17 @@ Connection.prototype.createConnection = function() {
 		trace("connection failed", delay);
 
 		this.raiseError(error);
-		this.emit('error', error);
 
-		if (this.options.connectionRetryLimit > 0 
+		// The 'error' event in Node is a special case that will make the
+		// process throw a stack trace and stop if it has no listeners. As we
+		// want to continue retrying, don't emit this event unless it has
+		// listeners.
+		// Resolves issue #219
+		if (this.listeners('error')) {
+			this.emit('error', error);
+		}
+
+		if (this.options.connectionRetryLimit > 0
 			&& this.failureCount > this.options.connectionRetryLimit
 			&& this.sockets.length == 0) {
 			this.rejectBuffer(Errors['connectionRetryLimitExceeded']);


### PR DESCRIPTION
Check that the "error" event has any registered listeners before emitting it. This prevents the process from dying as that would be the default behaviour in node.

This PR resolves issue #219.