### PR TITLE
Default `autoAdjustCache` to false

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -60,7 +60,7 @@ function Connection (options) {
 		rejectUnauthorized: true,
 		enhanced: true,
 		cacheLength: 1000,
-		autoAdjustCache: true,
+		autoAdjustCache: false,
 		maxConnections: 1,
 		connectTimeout: 10000,
 		connectionTimeout: 0,


### PR DESCRIPTION
The documentation have always stated that the `autoAdjustCache` option will default to `false`, but it have always defaulted to `true`.

Maybe you should consider making this a breaking change, as peoples implementations already depend on the property being `true`. Also consider if the default in fact *should* be `true` and that it's the documentation that needs updating.