### PR TITLE
Update docs for `cacheLength` to show new default

### DIFF
--- a/doc/connection.markdown
+++ b/doc/connection.markdown
@@ -22,7 +22,7 @@ Options:
 
  - `enhanced` {Boolean} Whether to use the enhanced notification format (recommended, defaults to: `true`)
 
- - `cacheLength` {Number} Number of notifications to cache for error purposes (See "Handling Errors" below, (Defaults to: 100)
+ - `cacheLength` {Number} Number of notifications to cache for error purposes (See "Handling Errors" below, (Defaults to: 1000)
 
  - `autoAdjustCache` {Boolean} Whether the cache should grow in response to messages being lost after errors. (Will still emit a 'cacheTooSmall' event) (Defaults to: `false`)
 


### PR DESCRIPTION
The new default of `cacheLength` is now 1000 and not 100