### PR TITLE
Clear `connectionTimer` when a socket is closed

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -417,6 +417,11 @@ Connection.prototype.destroyConnection = function(socket) {
 Connection.prototype.socketClosed = function(socket) {
 	debug("Socket closed", socket.apnSocketId);
 
+	//clear the connectionTimer when we close a socket, because
+	//we call socket.end() on connectionTimer that causes an error to be thrown inside node
+	//Resolves #217
+	clearTimeout(this.connectionTimer);
+
 	if (socket === this.socket && this.deferredConnection.promise.isPending()) {
 		debug("Connection error occurred before TLS Handshake");
 		this.deferredConnection.reject(new Error("Unable to connect"));


### PR DESCRIPTION
Otherwise, when the timer expires socket.end() is called that causes a TypeError inside node libraries.
Fixes #217 