### PR TITLE
connection: Fix validate credentials

### DIFF
--- a/lib/credentials/validate.js
+++ b/lib/credentials/validate.js
@@ -12,7 +12,7 @@ function validateCredentials(credentials) {
 		throw new Error("certificate has expired: " + validity.notAfter.toJSON());
 	}
 
-	if (credentials.production !== undefined) {
+	if (credentials.production !== false) {
 		var environment = certificate.environment();
 		if ( (credentials.production && !environment.production) ||
 			(!credentials.production && !environment.sandbox)) {


### PR DESCRIPTION
Connection.production either returns true or false, validateCredentials
depends on Connection.production being undefined/defined (which it will
never be).