### PR TITLE
Add setTitleLocKey and setTitleLocArgs functions

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -142,7 +142,7 @@ Notification.prototype.setAlertText = function (text) {
 };
 
 /**
- * Set the alert title for the notification - used with Safari Push Notifications
+ * Set the alert title for the notification - used with Safari Push Notifications and iOS Push Notifications displayed on Apple Watch
  * @param {String} alertTitle The title for the alert.
  * @see The <a href="https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html#//apple_ref/doc/uid/TP40013225-CH3-SW12">Pushing Notifications</a> in the Notification Programming Guide for Websites
  * @since v1.5.0
@@ -150,6 +150,30 @@ Notification.prototype.setAlertText = function (text) {
 Notification.prototype.setAlertTitle = function(alertTitle) {
 	this.prepareAlert();
 	this.alert.title = alertTitle;
+	return this;
+};
+
+/**
+ * Set the alert title-loc-key for the notification - used with iOS Push Notifications displayed on Apple Watch. Please note: The corresponding localization key must be in your host app's (i.e. iPhone app) Localizable.strings file and not inside your WatchKit extension or WatchKit app.
+ * @param {String} titleLocKey The localization key for the alert title.
+ * @see The <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1">Payload Documentation</a>
+ * @since XXX
+ */
+Notification.prototype.setTitleLocKey = function(titleLocKey) {
+	this.prepareAlert();
+	this.alert["title-loc-key"] = titleLocKey;
+	return this;
+};
+
+/**
+ * Set the alert title-loc-args for the notification - used with iOS Push Notifications displayed on Apple Watch
+ * @param {String[]} [titleLocArgs] Variable string values to appear in place of the format specifiers in title-loc-key.
+ * @see The <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1">Payload Documentation</a>
+ * @since XXX
+ */
+Notification.prototype.setTitleLocArgs = function(titleLocArgs) {
+	this.prepareAlert();
+	this.alert["title-loc-args"] = titleLocArgs;
 	return this;
 };
 


### PR DESCRIPTION
Add setTitleLocKey and setTitleLocArgs functions to set new alert object keys introduced in iOS 8.2 (title-loc-key and title-loc-args)