### PR TITLE
Fix: Library was changing badge: 0 to badge: undefined

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -480,7 +480,7 @@ Notification.prototype.truncateStringToLength = function (string, length, encodi
 Notification.prototype.apsPayload = function() {
 	var aps = this.payload.aps || {};
 
-	aps.badge = this.badge || aps.badge;
+	aps.badge = typeof this.badge !== "undefined" ? this.badge : aps.badge;
 	aps.sound = this.sound || aps.sound;
 	aps.alert = this.alert || aps.alert;
 	if (this.contentAvailable) {


### PR DESCRIPTION
JS evaluated expression `0 || aps.badge` as `aps.badge` which is undefined.