### PR TITLE
Allow null payloads

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -478,7 +478,7 @@ Notification.prototype.truncateStringToLength = function (string, length, encodi
  * @private
  */
 Notification.prototype.apsPayload = function() {
-	var aps = this.payload.aps || {};
+	var aps = this.payload ? (this.payload.aps || {}) : {};
 
 	aps.badge = typeof this.badge !== "undefined" ? this.badge : aps.badge;
 	aps.sound = this.sound || aps.sound;


### PR DESCRIPTION
Got an error (can't read property aps of undefined) when trying to send a push notification with null payload.