### PR TITLE
Rich notifications (iOS 10)

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -338,7 +338,7 @@ Notification.prototype.setNewsstandAvailable = function (newsstandAvailable) {
 /**
  * Set the 'mutable-content' flag on the payload
  * @param {Boolean} [mutableContent] Whether the mutable-content flag should be set or not.
- * @since v1.3.5
+ * @since v1.7.8
  */
 Notification.prototype.setMutableContent = function (mutableContent) {
 	this.mutableContent = mutableContent;

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -64,6 +64,18 @@ Notification.prototype = {
 		this._contentAvailable = undefined;
 	},
 
+	get mutableContent() {
+		return this._mutableContent;
+	},
+	set mutableContent(value) {
+		this.compiled = false;
+		if (value === 1 || value === true) {
+			this._mutableContent = 1;
+			return;
+		}
+		this._mutableContent = undefined;
+	},
+
 	get newsstandAvailable() {
 		return this.contentAvailable;
 	},
@@ -121,6 +133,7 @@ Notification.prototype.clone = function (device) {
 	notification.sound = this.sound;
 	notification.newsstandAvailable = this.newsstandAvailable;
 	notification.contentAvailable = this.contentAvailable;
+	notification.mutableContent = this.mutableContent;
 	notification.mdm = this.mdm;
 	notification.truncateAtWordEnd = this.truncateAtWordEnd;
 	notification.urlArgs = this.urlArgs;
@@ -323,6 +336,16 @@ Notification.prototype.setNewsstandAvailable = function (newsstandAvailable) {
 };
 
 /**
+ * Set the 'mutable-content' flag on the payload
+ * @param {Boolean} [mutableContent] Whether the mutable-content flag should be set or not.
+ * @since v1.3.5
+ */
+Notification.prototype.setMutableContent = function (mutableContent) {
+	this.mutableContent = mutableContent;
+	return this;
+};
+
+/**
  * Set the 'mdm' flag on the payload
  * @param {Object} [mdm] The mdm property for the payload.
  * @since v1.3.5
@@ -403,7 +426,7 @@ Notification.prototype.trim = function(length) {
 	if(!escaped) {
 		return -tooLong;
 	}
-	
+
 	escaped = JSON.stringify(escaped).slice(1, -1); // trim quotes
 	length = Buffer.byteLength(escaped, encoding);
 	if (length < tooLong) {
@@ -452,7 +475,7 @@ function hasValidUnicodeTail(string, encoding) {
 Notification.prototype.truncateStringToLength = function (string, length, encoding) {
 	// Convert to a buffer and back to a string with the correct encoding to truncate the unicode series correctly.
 	var result = new Buffer(string, encoding).toString(encoding, 0, length);
-	
+
 	if (this.truncateAtWordEnd === true) {
 		var lastSpaceIndexInResult = result.lastIndexOf(" ");
 
@@ -486,7 +509,11 @@ Notification.prototype.apsPayload = function() {
 	if (this.contentAvailable) {
 		aps["content-available"] = 1;
 	}
-	
+
+	if (this.mutableContent) {
+		aps["mutable-content"] = 1;
+	}
+
 	aps["url-args"] = this.urlArgs || aps["url-args"];
 	aps.category = this.category || aps.category;
 
@@ -500,7 +527,7 @@ Notification.prototype.toJSON = function () {
 		this.payload.mdm = this.mdm;
 		return this.payload;
 	}
-	
+
 	this.payload.aps = this.apsPayload();
 
 	return this.payload;

--- a/test/connection.js
+++ b/test/connection.js
@@ -268,7 +268,7 @@ describe("Connection", function() {
 
 		it("loadCredentialss the module", function(done) {
 			var connection = Connection({ pfx: "myCredentials.pfx" });
-			return connection.createSocket().finally(function() {
+			connection.createSocket().finally(function() {
 				expect(connection.loadCredentials).to.have.been.calledOnce;
 				done();
 			});

--- a/test/feedback.js
+++ b/test/feedback.js
@@ -263,7 +263,7 @@ describe("Feedback", function() {
 
 		it("loads credentials", function(done) {
 			var feedback = Feedback({ pfx: "myCredentials.pfx" });
-			return feedback.createSocket().finally(function() {
+			feedback.createSocket().finally(function() {
 				expect(feedback.loadCredentials).to.have.been.calledOnce;
 				done();
 			});

--- a/test/notification.js
+++ b/test/notification.js
@@ -680,7 +680,7 @@ describe("Notification", function() {
 
 			describe("with contentAvailable property disabled", function() {
 				it("does not set the 'content-available' flag", function() {
-          note.alert = "message";
+					note.alert = "message";
 					note.contentAvailable = false;
 
 					expect(note.toJSON().aps["content-available"]).to.be.undefined;
@@ -697,7 +697,7 @@ describe("Notification", function() {
 
 			describe("with mutableContent property disabled", function() {
 				it("does not set the 'mutable-content' flag", function() {
-          note.alert = "message";
+					note.alert = "message";
 					note.mutableContent = false;
 
 					expect(note.toJSON().aps["mutable-content"]).to.be.undefined;
@@ -707,7 +707,7 @@ describe("Notification", function() {
 			describe("with newsstandAvailable property", function() {
 				it("sets the 'content-available' flag", function() {
 					note.contentAvailable = true;
-
+					
 					expect(note.toJSON().aps["content-available"]).to.eql(1);
 				});
 			});

--- a/test/notification.js
+++ b/test/notification.js
@@ -172,6 +172,51 @@ describe("Notification", function() {
 			});
 		});
 
+		describe("mutable-content property", function() {
+			it("defaults to undefined", function() {
+				expect(note.mutableContent).to.be.undefined;
+			});
+
+			it("can be set to `1` with a boolean value", function() {
+				note.mutableContent = true;
+				expect(note.mutableContent).to.equal(1);
+			});
+
+			it("resets the `compiled` flag when enabled", function() {
+				note.compiled = true;
+				note.mutableContent = true;
+				expect(note.compiled).to.be.false;
+			});
+
+			it("resets the `compiled` flag when disabled", function() {
+				note.compiled = true;
+				note.mutableContent = false;
+				expect(note.compiled).to.be.false;
+			});
+
+			it("can be set to undefined", function() {
+				note.mutableContent = true;
+				note.mutableContent = undefined;
+				expect(note.mutableContent).to.be.undefined;
+			});
+
+			it("can be set to `1`", function() {
+				note.mutableContent = 1;
+				expect(typeof note.mutableContent).to.equal("number");
+			});
+
+			it("cannot be set to a string", function() {
+				note.mutableContent = "true";
+				expect(note.mutableContent).to.be.undefined;
+			});
+
+			it("can be disabled", function() {
+				note.mutableContent = false;
+				expect(note.mutableContent).to.be.undefined;
+			});
+
+		});
+
 		describe("mdm property", function() {
 			it("defaults to undefined", function() {
 				expect(note.mdm).to.be.undefined;
@@ -338,7 +383,7 @@ describe("Notification", function() {
 					note.trim();
 					expect(note.length()).to.equal(2048);
 				});
-				
+
 				it("trims notification alert body to reduce payload to maximum length", function () {
 					note.alert = {
 						body: longText
@@ -397,7 +442,7 @@ describe("Notification", function() {
 					note.trim(trimLength);
 					expect(note.alert).to.equal("\n\n");
 				});
-				
+
 				it("leaves escaped escape character intact", function() {
 					note.alert = "test\\ message";
 					note.trim(26);
@@ -467,7 +512,7 @@ describe("Notification", function() {
 
 					expect(note.length()).to.equal(48);
 				});
-				
+
 				it("correctly empties the string", function() {
 					note.alert = Buffer([0x3D, 0xD8, 0x03, 0xDE, 0x3D, 0xD8, 0x1E, 0xDE]).toString(note.encoding);
 					var trimLength = note.length() - 8;
@@ -628,7 +673,7 @@ describe("Notification", function() {
 			describe("with contentAvailable property", function() {
 				it("sets the 'content-available' flag", function() {
 					note.contentAvailable = true;
-					
+
 					expect(note.toJSON().aps["content-available"]).to.eql(1);
 				});
 			});
@@ -637,15 +682,32 @@ describe("Notification", function() {
 				it("does not set the 'content-available' flag", function() {
           note.alert = "message";
 					note.contentAvailable = false;
-					
+
 					expect(note.toJSON().aps["content-available"]).to.be.undefined;
+				});
+			});
+
+			describe("with mutableContent property", function() {
+				it("sets the 'mutable-content' flag", function() {
+					note.mutableContent = true;
+
+					expect(note.toJSON().aps["mutable-content"]).to.eql(1);
+				});
+			});
+
+			describe("with mutableContent property disabled", function() {
+				it("does not set the 'mutable-content' flag", function() {
+          note.alert = "message";
+					note.mutableContent = false;
+
+					expect(note.toJSON().aps["mutable-content"]).to.be.undefined;
 				});
 			});
 
 			describe("with newsstandAvailable property", function() {
 				it("sets the 'content-available' flag", function() {
 					note.contentAvailable = true;
-					
+
 					expect(note.toJSON().aps["content-available"]).to.eql(1);
 				});
 			});


### PR DESCRIPTION
In iOS 10, remote notification payloads can be mutated on the client before presentation to the user, allowing for rich content to be displayed (images, video).

The key to this is a `mutable-content` boolean value in the payload that must be set to `1`.

Further information in the WWDC presentation (page 16): http://devstreaming.apple.com/videos/wwdc/2016/708tbh8wnspsg01hxwx/708/708_advanced_notifications.pdf