### PR TITLE
deps: nail down verror dependency to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "debug": "^2.2.0",
     "http2": "https://github.com/argon/node-http2#apn-2.0.0",
     "node-forge": "^0.6.20",
-    "verror": "*"
+    "verror": "^1.8.1"
   },
   "devDependencies": {
     "chai": "3.x",


### PR DESCRIPTION
Well, the title says it all :)

Why did do that? I have the issue that a dependency (jsprim) is using verror in version 1.3.6 in which an access to VError is done with `require('verror').VError`.