### PR TITLE
Update README for APNS Auth Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ note.badge = 3;
 note.sound = "ping.aiff";
 note.alert = "\uD83D\uDCE7 \u2709 You have a new message";
 note.payload = {'messageFrom': 'John Appleseed'};
+note.topic = 'your app bundle id'; //require to work with APNS Auth Key
 ```
 
 Send the notification to the API with `send`, which returns a promise.


### PR DESCRIPTION
For `APNS Auth Key` push notification, `topic` is required. I don't have time to make changes in the code to require this, but a simple documentation would help. 